### PR TITLE
Remove unused tokenizer

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -3,8 +3,6 @@ from core.chat import conversar
 from core.memoria import carregar_memoria
 import time
 import psutil
-from transformers import GPT2TokenizerFast
-tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 memoria = carregar_memoria()
 
 def responder(pergunta, historico):


### PR DESCRIPTION
## Summary
- clean up imports in `interface.py`

## Testing
- `python -m py_compile interface.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_68438b3cbd1483279645d24875bc87b0