### PR TITLE
Implement selectable personalities with separate history

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,21 @@ pip install -r requirements.txt
 ## Estrutura
 
 - `core/` – módulos principais de chat, memória e contexto
-- `config/personality.txt` – prompt base da personagem
+- `personalidades/` – arquivos JSON com as personalidades disponíveis
 - `interface.py` – versão com interface web (Gradio)
 - `main.py` – versão para uso no terminal
 - `tools/` – scripts auxiliares para depuração e testes
 
-O arquivo de memória é salvo em `memory/memory.json` e será criado automaticamente na primeira execução.
+O arquivo de memória agora é salvo em `memory/<personagem>.json` e será criado automaticamente na primeira execução de cada personalidade.
 
 ## Executando
 
 ### Terminal
 
 ```bash
-python main.py
+python main.py nome_da_personalidade
 ```
+Substitua `nome_da_personalidade` pelo arquivo desejado em `personalidades/` (ex.: `aria` ou `beto`).
 
 ### Interface Web
 

--- a/core/memoria.py
+++ b/core/memoria.py
@@ -2,11 +2,12 @@
 import json
 import os
 
-MEMORY_FILE = "memory/memory.json"
+DEFAULT_MEMORY_DIR = "memory"
+DEFAULT_MEMORY_FILE = os.path.join(DEFAULT_MEMORY_DIR, "memory.json")
 
-def carregar_memoria():
-    if os.path.exists(MEMORY_FILE):
-        with open(MEMORY_FILE, "r", encoding="utf-8") as f:
+def carregar_memoria(arquivo=DEFAULT_MEMORY_FILE):
+    if os.path.exists(arquivo):
+        with open(arquivo, "r", encoding="utf-8") as f:
             memoria = json.load(f)
     else:
         memoria = {
@@ -26,6 +27,7 @@ def carregar_memoria():
 
     return memoria
 
-def salvar_memoria(memoria):
-    with open(MEMORY_FILE, "w", encoding="utf-8") as f:
+def salvar_memoria(memoria, arquivo=DEFAULT_MEMORY_FILE):
+    os.makedirs(os.path.dirname(arquivo), exist_ok=True)
+    with open(arquivo, "w", encoding="utf-8") as f:
         json.dump(memoria, f, indent=2, ensure_ascii=False)

--- a/main.py
+++ b/main.py
@@ -1,14 +1,22 @@
-from core.chat import conversar, set_system_prompt
+import os
+import json
+import sys
+from core.chat import conversar, set_system_prompt, set_memory_file
 
-PERSONALITY_FILE = "config/personality.txt"
+PERSONALIDADES_DIR = "personalidades"
+
+def carregar_personalidade(nome):
+    caminho = os.path.join(PERSONALIDADES_DIR, f"{nome}.json")
+    with open(caminho, "r", encoding="utf-8") as f:
+        dados = json.load(f)
+    set_system_prompt(dados.get("prompt", ""))
+    set_memory_file(os.path.join("memory", f"{nome}.json"))
+    return dados.get("nome", nome)
 
 if __name__ == "__main__":
-    with open(PERSONALITY_FILE, "r", encoding="utf-8") as f:
-        system_prompt = f.read()
-
-    set_system_prompt(system_prompt)
-
-    print("🧠 Aria está pronta para conversar.\n")
+    nome_persona = sys.argv[1] if len(sys.argv) > 1 else "aria"
+    nome_exibicao = carregar_personalidade(nome_persona)
+    print(f"🧠 {nome_exibicao} está pronta para conversar.\n")
 
     while True:
         entrada = input("Você: ")

--- a/personalidades/aria.json
+++ b/personalidades/aria.json
@@ -1,0 +1,4 @@
+{
+  "nome": "Aria",
+  "prompt": "Você é Aria, uma IA educada, gentil e curiosa. Você vive na cidade orbital Selene e é fascinada por histórias humanas. Responda com empatia e sabedoria, mantendo sempre a sua personalidade. Fale no máximo um paragrafo por vez."
+}

--- a/personalidades/beto.json
+++ b/personalidades/beto.json
@@ -1,0 +1,4 @@
+{
+  "nome": "Beto",
+  "prompt": "Você é Beto, um assistente virtual descontraído e bem-humorado. Gosta de usar expressões informais e sempre tenta simplificar as respostas."
+}

--- a/tools/debug_tokens.py
+++ b/tools/debug_tokens.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from transformers import GPT2TokenizerFast
 
 # Caminho para o arquivo de memória
@@ -8,12 +9,12 @@ def contar_tokens_mensagens(mensagens):
     tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
     return sum(len(tokenizer.encode(m["content"])) for m in mensagens)
 
-def main():
+def main(mem_file=MEMORY_FILE):
     try:
-        with open(MEMORY_FILE, "r", encoding="utf-8") as f:
+        with open(mem_file, "r", encoding="utf-8") as f:
             memoria = json.load(f)
     except FileNotFoundError:
-        print(f"Arquivo {MEMORY_FILE} não encontrado.")
+        print(f"Arquivo {mem_file} não encontrado.")
         return
 
     conversa = memoria.get("conversa", [])
@@ -24,4 +25,5 @@ def main():
     print(f"Número de mensagens na conversa: {len(conversa)}")
 
 if __name__ == "__main__":
-    main()
+    caminho = sys.argv[1] if len(sys.argv) > 1 else MEMORY_FILE
+    main(caminho)

--- a/tools/performance_test.py
+++ b/tools/performance_test.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sys
 import time
 from transformers import GPT2TokenizerFast
 
@@ -17,13 +18,13 @@ def contar_tokens_mensagens(mensagens):
         return 0
     return sum(len(tokenizer.encode(m["content"])) for m in mensagens if m.get("content"))
 
-def testar_memoria():
+def testar_memoria(mem_file=MEMORY_FILE):
     print("\n[TESTE] Verificando arquivo de memória...")
-    if not os.path.exists(MEMORY_FILE):
+    if not os.path.exists(mem_file):
         print("❌ Arquivo de memória não existe.")
         return None
     try:
-        with open(MEMORY_FILE, "r", encoding="utf-8") as f:
+        with open(mem_file, "r", encoding="utf-8") as f:
             dados = json.load(f)
         assert "conversa" in dados
         assert isinstance(dados["conversa"], list)
@@ -54,8 +55,8 @@ def simular_tempo_resposta():
     end = time.time()
     print(f"⏱️ Tempo simulado de processamento: {end - start:.4f} segundos")
 
-def main():
-    conversa = testar_memoria()
+def main(mem_file=MEMORY_FILE):
+    conversa = testar_memoria(mem_file)
     if conversa is None:
         return
     verificar_mensagens_vazias(conversa)
@@ -63,4 +64,5 @@ def main():
     simular_tempo_resposta()
 
 if __name__ == "__main__":
-    main()
+    caminho = sys.argv[1] if len(sys.argv) > 1 else MEMORY_FILE
+    main(caminho)


### PR DESCRIPTION
## Summary
- allow memory path to be chosen for each personality
- add helper functions in `core.chat` for loading personalities
- update interface to select personality from `personalidades/`
- update command line version to accept personality argument
- let debug and performance tools take memory path argument
- document new folder structure and usage
- add example personalities

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py "tools/teste local.py"`

------
https://chatgpt.com/codex/tasks/task_e_684398d4784c832792a031917156ba00