### PR TITLE
Add hierarchical memory support

### DIFF
--- a/core/memoria.py
+++ b/core/memoria.py
@@ -3,7 +3,12 @@ import json
 import os
 
 DEFAULT_MEMORY_DIR = "memory"
-DEFAULT_MEMORY_FILE = os.path.join(DEFAULT_MEMORY_DIR, "memory.json")
+DEFAULT_MEMORY_FILE = os.path.join(DEFAULT_MEMORY_DIR, "working_memory.json")
+
+RAW_ROTATE = 500  # mensagens por arquivo raw
+EPISODE_SIZE = 10
+EPISODES_PER_BRANCH = 4
+BRANCHES_PER_GLOBAL = 4
 
 def carregar_memoria(arquivo=DEFAULT_MEMORY_FILE):
     if os.path.exists(arquivo):
@@ -31,3 +36,151 @@ def salvar_memoria(memoria, arquivo=DEFAULT_MEMORY_FILE):
     os.makedirs(os.path.dirname(arquivo), exist_ok=True)
     with open(arquivo, "w", encoding="utf-8") as f:
         json.dump(memoria, f, indent=2, ensure_ascii=False)
+
+
+def _load_json(path, default):
+    if os.path.exists(path):
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return default
+
+
+def _save_json(data, path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+
+
+def _append_jsonl(path, obj):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "a", encoding="utf-8") as f:
+        json.dump(obj, f, ensure_ascii=False)
+        f.write("\n")
+
+
+def _load_meta(base_dir):
+    return _load_json(os.path.join(base_dir, "meta.json"), {
+        "current_raw": 1,
+        "count_in_raw": 0,
+        "last_id": 0
+    })
+
+
+def _save_meta(meta, base_dir):
+    _save_json(meta, os.path.join(base_dir, "meta.json"))
+
+
+def init_hierarchical(base_dir):
+    os.makedirs(os.path.join(base_dir, "raw"), exist_ok=True)
+    for fname in ["episodic_summaries.json", "historical_summaries.json", "global_summary.json"]:
+        path = os.path.join(base_dir, fname)
+        if not os.path.exists(path):
+            _save_json([], path)
+    if not os.path.exists(os.path.join(base_dir, "meta.json")):
+        _save_meta({"current_raw": 1, "count_in_raw": 0, "last_id": 0}, base_dir)
+
+
+def registrar_raw(role, content, base_dir):
+    meta = _load_meta(base_dir)
+    msg_id = meta["last_id"] + 1
+    raw_file = os.path.join(base_dir, "raw", f"raw_{meta['current_raw']}.jsonl")
+    _append_jsonl(raw_file, {"id": msg_id, "role": role, "content": content})
+    meta["last_id"] = msg_id
+    meta["count_in_raw"] += 1
+    if meta["count_in_raw"] >= RAW_ROTATE:
+        meta["current_raw"] += 1
+        meta["count_in_raw"] = 0
+    _save_meta(meta, base_dir)
+    return msg_id
+
+
+def _ler_raw_intervalo(base_dir, start_id, end_id):
+    meta = _load_meta(base_dir)
+    mensagens = []
+    for idx in range(1, meta["current_raw"] + 1):
+        arq = os.path.join(base_dir, "raw", f"raw_{idx}.jsonl")
+        if not os.path.exists(arq):
+            continue
+        with open(arq, "r", encoding="utf-8") as f:
+            for linha in f:
+                if not linha.strip():
+                    continue
+                msg = json.loads(linha)
+                if msg["id"] < start_id:
+                    continue
+                mensagens.append(msg)
+                if msg["id"] >= end_id:
+                    return mensagens
+    return mensagens
+
+
+def _save_episodic_summary(base_dir, start_id, end_id, resumo):
+    arquivo = os.path.join(base_dir, "episodic_summaries.json")
+    episodios = _load_json(arquivo, [])
+    episodios.append({
+        "id": len(episodios) + 1,
+        "start_id": start_id,
+        "end_id": end_id,
+        "summary": resumo,
+    })
+    _save_json(episodios, arquivo)
+
+
+def _save_branch_summary(base_dir, episodic_ids, resumo):
+    arquivo = os.path.join(base_dir, "historical_summaries.json")
+    branches = _load_json(arquivo, [])
+    branches.append({
+        "id": len(branches) + 1,
+        "episodic_ids": episodic_ids,
+        "summary": resumo,
+    })
+    _save_json(branches, arquivo)
+
+
+def _save_global_summary(base_dir, branch_ids, resumo):
+    arquivo = os.path.join(base_dir, "global_summary.json")
+    globais = _load_json(arquivo, [])
+    globais.append({
+        "id": len(globais) + 1,
+        "branch_ids": branch_ids,
+        "summary": resumo,
+    })
+    _save_json(globais, arquivo)
+
+
+def gerar_resumo_episodio(base_dir, resumo_func):
+    meta = _load_meta(base_dir)
+    if meta["last_id"] % EPISODE_SIZE != 0:
+        return None
+    start_id = meta["last_id"] - EPISODE_SIZE + 1
+    mensagens = _ler_raw_intervalo(base_dir, start_id, meta["last_id"])
+    trechos = [f"{'Usuário' if m['role']=='user' else 'IA'}: {m['content']}" for m in mensagens]
+    resumo = resumo_func(trechos)
+    _save_episodic_summary(base_dir, start_id, meta["last_id"], resumo)
+    return resumo
+
+
+def gerar_resumo_branch(base_dir, resumo_func):
+    episodios = _load_json(os.path.join(base_dir, "episodic_summaries.json"), [])
+    branches = _load_json(os.path.join(base_dir, "historical_summaries.json"), [])
+    if len(episodios) < EPISODES_PER_BRANCH * (len(branches) + 1):
+        return None
+    start = len(branches) * EPISODES_PER_BRANCH
+    subset = episodios[start:start + EPISODES_PER_BRANCH]
+    trechos = [e["summary"] for e in subset]
+    resumo = resumo_func(trechos)
+    _save_branch_summary(base_dir, [e["id"] for e in subset], resumo)
+    return resumo
+
+
+def gerar_resumo_global(base_dir, resumo_func):
+    branches = _load_json(os.path.join(base_dir, "historical_summaries.json"), [])
+    globais = _load_json(os.path.join(base_dir, "global_summary.json"), [])
+    if len(branches) < BRANCHES_PER_GLOBAL * (len(globais) + 1):
+        return None
+    start = len(globais) * BRANCHES_PER_GLOBAL
+    subset = branches[start:start + BRANCHES_PER_GLOBAL]
+    trechos = [b["summary"] for b in subset]
+    resumo = resumo_func(trechos)
+    _save_global_summary(base_dir, [b["id"] for b in subset], resumo)
+    return resumo

--- a/core/resumo.py
+++ b/core/resumo.py
@@ -18,3 +18,32 @@ def gerar_resumo_com_ia(trechos):
     response = requests.post(LM_API_URL, json=payload)
     resposta = response.json()["choices"][0]["message"]["content"].strip()
     return resposta
+
+
+def gerar_resumo_custom(trechos, prompt_resumo):
+    texto_completo = prompt_resumo + "\n".join(trechos)
+    payload = {
+        "model": "local-model",
+        "messages": [
+            {"role": "user", "content": texto_completo}
+        ],
+        "temperature": 0.5,
+        "max_tokens": 250
+    }
+    response = requests.post(LM_API_URL, json=payload)
+    return response.json()["choices"][0]["message"]["content"].strip()
+
+
+def resumo_episodio(trechos):
+    prompt = "Resuma em exatamente 7 tópicos os eventos a seguir:\n\n"
+    return gerar_resumo_custom(trechos, prompt)
+
+
+def resumo_branch(trechos):
+    prompt = "Contextualize os episódios em um parágrafo seguido de bullets:\n\n"
+    return gerar_resumo_custom(trechos, prompt)
+
+
+def resumo_global(trechos):
+    prompt = "Faça uma visão geral da história em parágrafos curtos:\n\n"
+    return gerar_resumo_custom(trechos, prompt)

--- a/interface.py
+++ b/interface.py
@@ -31,7 +31,7 @@ PERSONALIDADE_PADRAO = list(PERSONALIDADES.keys())[0]
 def inicializar_personalidade(nome):
     info = PERSONALIDADES[nome]
     chat.set_system_prompt(info["dados"].get("prompt", ""))
-    caminho_mem = os.path.join("memory", f"{info['id']}.json")
+    caminho_mem = os.path.join("memory", info["id"])
     chat.set_memory_file(caminho_mem)
 
 inicializar_personalidade(PERSONALIDADE_PADRAO)

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ def carregar_personalidade(nome):
     with open(caminho, "r", encoding="utf-8") as f:
         dados = json.load(f)
     set_system_prompt(dados.get("prompt", ""))
-    set_memory_file(os.path.join("memory", f"{nome}.json"))
+    set_memory_file(os.path.join("memory", nome))
     return dados.get("nome", nome)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement hierarchical memory rotation and episodic/branch/global summaries
- wire chat module to register messages in new memory structure
- update summarization utilities for episodic, branch and global summaries
- adjust interface and CLI to use memory directories

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py "tools/teste_local.py"`

------
https://chatgpt.com/codex/tasks/task_e_6843a038c25883278161febbe7b81e4c