### PR TITLE
Handle raw log deletion when removing last message

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -4,7 +4,7 @@ import json
 import time
 import psutil
 import core.chat as chat
-from core.memoria import salvar_memoria
+from core.memoria import salvar_memoria, remover_ultimas_raw
 from transformers import GPT2TokenizerFast
 tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 
@@ -95,6 +95,7 @@ def excluir_ultima_interacao(historico):
         del historico[-2:]
         if chat.memoria.get("conversa"):
             chat.memoria["conversa"] = chat.memoria["conversa"][:-2]
+            remover_ultimas_raw(chat.memory_base, 2)
             salvar_memoria(chat.memoria, chat.memory_file)
     return historico, historico
 


### PR DESCRIPTION
## Summary
- implement `remover_ultimas_raw` to delete last messages from hierarchical logs
- update interface to call new helper when user removes the last interaction

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_6843be1054b083279aa0021265cf80fb