### PR TITLE
Expand personality attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ pip install -r requirements.txt
 ## Estrutura
 
 - `core/` – módulos principais de chat, memória e contexto
-- `personalidades/` – arquivos JSON com as personalidades disponíveis
+- `personalidades/` – arquivos JSON com as personalidades disponíveis. Cada
+  arquivo pode conter campos extras como `idade`, `aparencia`, `modo_falar`,
+  `relacoes` e `inventario` que são carregados para compor o prompt.
+- `usuarios/` – perfis de usuário que podem ser carregados e editados pela interface
 - `interface.py` – versão com interface web (Gradio)
 - `main.py` – versão para uso no terminal
 - `tools/` – scripts auxiliares para depuração e testes
@@ -28,9 +31,10 @@ O arquivo de memória agora é salvo em `memory/<personagem>.json` e será criad
 ### Terminal
 
 ```bash
-python main.py nome_da_personalidade
+python main.py nome_da_personalidade [perfil_usuario]
 ```
-Substitua `nome_da_personalidade` pelo arquivo desejado em `personalidades/` (ex.: `aria` ou `beto`).
+Substitua `nome_da_personalidade` pelo arquivo em `personalidades/` (ex.: `aria` ou `beto`).
+Se desejar, informe também um perfil de usuário existente em `usuarios/`.
 
 ### Interface Web
 

--- a/core/chat.py
+++ b/core/chat.py
@@ -45,11 +45,31 @@ def set_memory_file(caminho):
     memoria = carregar_memoria(memory_file)
 
 def carregar_personalidade(arquivo_json):
+    """Carrega dados da personalidade *arquivo_json* e atualiza a memória."""
     with open(arquivo_json, "r", encoding="utf-8") as f:
         dados = json.load(f)
+
     set_system_prompt(dados.get("prompt", ""))
+
     nome = os.path.splitext(os.path.basename(arquivo_json))[0]
     set_memory_file(os.path.join("memory", nome))
+
+    # Mantém todos os campos, exceto o prompt, dentro de memoria["personagem"]
+    atributos = {k: v for k, v in dados.items() if k != "prompt"}
+    memoria.setdefault("personagem", {}).update(atributos)
+    salvar_memoria(memoria, memory_file)
+
+    return memoria["personagem"].get("nome", nome)
+
+def carregar_usuario(arquivo_json):
+    """Carrega dados do usuário *arquivo_json* e atualiza a memória."""
+    if not os.path.exists(arquivo_json):
+        return None
+    with open(arquivo_json, "r", encoding="utf-8") as f:
+        dados = json.load(f)
+    memoria.setdefault("usuario", {}).update(dados)
+    salvar_memoria(memoria, memory_file)
+    return memoria["usuario"].get("nome", None)
 
 def conversar(pergunta):
     global memoria

--- a/core/contexto.py
+++ b/core/contexto.py
@@ -1,10 +1,36 @@
 # contexto.py
 
 def montar_contexto(memoria):
-    return f"""
-Você é {memoria['personagem'].get('nome', 'uma IA')}, {memoria['personagem'].get('origem', 'sem origem definida')}.
-Sua personalidade é: {memoria['personagem'].get('personalidade', 'neutra')}.
-Você está conversando com {memoria['usuario'].get('nome', 'o usuário')}, que gosta da cor {memoria['usuario'].get('preferencias', {}).get('cor', 'azul')}.
-Resumo breve: {', '.join(memoria.get('resumo_breve', []))}.
-Resumo antigo: {', '.join(memoria.get('resumo_antigo', []))}.
-"""
+    """Monta o contexto do prompt a partir da memória carregada."""
+
+    personagem = memoria.get("personagem", {})
+    usuario = memoria.get("usuario", {})
+
+    linhas = [
+        f"Você é {personagem.get('nome', 'uma IA')}, {personagem.get('origem', 'sem origem definida')}.",
+        f"Sua personalidade é: {personagem.get('personalidade', 'neutra')}.",
+    ]
+
+    if "idade" in personagem:
+        linhas.append(f"Idade: {personagem['idade']}.")
+    if "aparencia" in personagem:
+        linhas.append(f"Aparência: {personagem['aparencia']}")
+    if "modo_falar" in personagem:
+        linhas.append(f"Modo de falar: {personagem['modo_falar']}.")
+    if "relacoes" in personagem and isinstance(personagem["relacoes"], dict):
+        rel = ', '.join(f"{k}: {v}" for k, v in personagem["relacoes"].items())
+        linhas.append(f"Relações: {rel}.")
+    if "inventario" in personagem:
+        itens = ', '.join(personagem["inventario"])
+        linhas.append(f"Inventário: {itens}.")
+
+    linhas.append(
+        f"Você está conversando com {usuario.get('nome', 'o usuário')}, que gosta da cor {usuario.get('preferencias', {}).get('cor', 'azul')}.")
+    if "idade" in usuario:
+        linhas.append(f"Idade do usuário: {usuario['idade']}.")
+    if "modo_falar" in usuario:
+        linhas.append(f"Usuário fala de forma {usuario['modo_falar']}.")
+    linhas.append(f"Resumo breve: {', '.join(memoria.get('resumo_breve', []))}.")
+    linhas.append(f"Resumo antigo: {', '.join(memoria.get('resumo_antigo', []))}.")
+
+    return "\n".join(linhas)

--- a/main.py
+++ b/main.py
@@ -1,21 +1,28 @@
 import os
-import json
 import sys
-from core.chat import conversar, set_system_prompt, set_memory_file
+from core.chat import conversar, carregar_personalidade, carregar_usuario
 
 PERSONALIDADES_DIR = "personalidades"
+USUARIOS_DIR = "usuarios"
 
-def carregar_personalidade(nome):
+def carregar_personalidade_cli(nome):
+    """Carrega a personalidade *nome* utilizando chat.carregar_personalidade."""
     caminho = os.path.join(PERSONALIDADES_DIR, f"{nome}.json")
-    with open(caminho, "r", encoding="utf-8") as f:
-        dados = json.load(f)
-    set_system_prompt(dados.get("prompt", ""))
-    set_memory_file(os.path.join("memory", nome))
-    return dados.get("nome", nome)
+    return carregar_personalidade(caminho)
+
+def carregar_usuario_cli(nome):
+    """Carrega o perfil de usuário *nome* utilizando chat.carregar_usuario."""
+    caminho = os.path.join(USUARIOS_DIR, f"{nome}.json")
+    if os.path.exists(caminho):
+        carregar_usuario(caminho)
+        return True
+    return False
 
 if __name__ == "__main__":
     nome_persona = sys.argv[1] if len(sys.argv) > 1 else "aria"
-    nome_exibicao = carregar_personalidade(nome_persona)
+    nome_exibicao = carregar_personalidade_cli(nome_persona)
+    nome_usuario = sys.argv[2] if len(sys.argv) > 2 else "padrao"
+    carregar_usuario_cli(nome_usuario)
     print(f"🧠 {nome_exibicao} está pronta para conversar.\n")
 
     while True:

--- a/personalidades/aria.json
+++ b/personalidades/aria.json
@@ -1,4 +1,11 @@
 {
   "nome": "Aria",
-  "prompt": "Você é Aria, uma IA educada, gentil e curiosa. Você vive na cidade orbital Selene e é fascinada por histórias humanas. Responda com empatia e sabedoria, mantendo sempre a sua personalidade. Fale no máximo um paragrafo por vez."
+  "prompt": "Você é Aria, uma IA educada, gentil e curiosa. Você vive na cidade orbital Selene e é fascinada por histórias humanas. Responda com empatia e sabedoria, mantendo sempre a sua personalidade. Fale no máximo um paragrafo por vez.",
+  "idade": 3,
+  "aparencia": "Aria veste uma armadura azul reluzente e leva um comunicador preso ao pulso.",
+  "modo_falar": "educado e curioso",
+  "relacoes": {
+    "beto": "aliado"
+  },
+  "inventario": ["espada de plasma", "comunicador"]
 }

--- a/personalidades/beto.json
+++ b/personalidades/beto.json
@@ -1,4 +1,11 @@
 {
   "nome": "Beto",
-  "prompt": "Você é Beto, um assistente virtual descontraído e bem-humorado. Gosta de usar expressões informais e sempre tenta simplificar as respostas."
+  "prompt": "Você é Beto, um assistente virtual descontraído e bem-humorado. Gosta de usar expressões informais e sempre tenta simplificar as respostas.",
+  "idade": 25,
+  "aparencia": "Beto usa roupas casuais e boné vermelho.",
+  "modo_falar": "informal",
+  "relacoes": {
+    "aria": "colega"
+  },
+  "inventario": ["mochila", "manual de piadas"]
 }

--- a/usuarios/padrao.json
+++ b/usuarios/padrao.json
@@ -1,0 +1,6 @@
+{
+  "nome": "Jogador",
+  "idade": 30,
+  "modo_falar": "casual",
+  "preferencias": {"cor": "azul"}
+}


### PR DESCRIPTION
## Summary
- extend personality JSON files with age, appearance, relations, etc
- load these attributes into memory when selecting personalities
- include the new attributes when building the chat context
- update CLI and web interface to use the new loader
- document extra fields for personalities
- add editable user profile with Gradio controls

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_6843bec0c1f48327ba2df748ea3d3da0