### PR TITLE
Improve error handling for HTTP requests

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -92,6 +92,8 @@ def conversar(pergunta):
     resposta = ""
     try:
         with requests.post(LM_API_URL, json=payload, stream=True) as response:
+            if response.status_code != 200:
+                response.raise_for_status()
             for linha in response.iter_lines():
                 if linha:
                     try:
@@ -102,10 +104,10 @@ def conversar(pergunta):
                         token = data["choices"][0]["delta"].get("content", "")
                         resposta += token
                         yield token
-                    except:
+                    except Exception:
                         continue
-    except:
-        yield "[Erro: não foi possível gerar resposta]"
+    except requests.RequestException as exc:
+        yield f"[Erro na requisição: {exc}]"
         return
 
     # Salva a resposta completa e registra em memória hierárquica

--- a/core/resumo.py
+++ b/core/resumo.py
@@ -15,9 +15,14 @@ def gerar_resumo_com_ia(trechos):
         "max_tokens": 250
     }
 
-    response = requests.post(LM_API_URL, json=payload)
-    resposta = response.json()["choices"][0]["message"]["content"].strip()
-    return resposta
+    try:
+        response = requests.post(LM_API_URL, json=payload)
+        if response.status_code != 200:
+            response.raise_for_status()
+        resposta = response.json()["choices"][0]["message"]["content"].strip()
+        return resposta
+    except requests.RequestException as exc:
+        return f"[Erro na requisição: {exc}]"
 
 
 def gerar_resumo_custom(trechos, prompt_resumo):
@@ -30,8 +35,13 @@ def gerar_resumo_custom(trechos, prompt_resumo):
         "temperature": 0.5,
         "max_tokens": 250
     }
-    response = requests.post(LM_API_URL, json=payload)
-    return response.json()["choices"][0]["message"]["content"].strip()
+    try:
+        response = requests.post(LM_API_URL, json=payload)
+        if response.status_code != 200:
+            response.raise_for_status()
+        return response.json()["choices"][0]["message"]["content"].strip()
+    except requests.RequestException as exc:
+        return f"[Erro na requisição: {exc}]"
 
 
 def resumo_episodio(trechos):


### PR DESCRIPTION
## Summary
- check HTTP status in `chat.conversar` streaming requests
- return request errors in summary functions

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py "tools/teste_local.py"`

------
https://chatgpt.com/codex/tasks/task_e_684b6601ca888327bcc7a210a9ec8e90