### PR TITLE
Fix memory path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -r requirements.txt
 - `main.py` – versão para uso no terminal
 - `tools/` – scripts auxiliares para depuração e testes
 
-O arquivo de memória agora é salvo em `memory/<personagem>.json` e será criado automaticamente na primeira execução de cada personalidade.
+Cada personalidade armazena sua memória em `memory/<personagem>/working_memory.json`, criado automaticamente na primeira execução.
 
 ## Executando
 


### PR DESCRIPTION
## Summary
- clarify working memory path per personality in README

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684b66041e188327a50853102c5c44a3