### PR TITLE
Fix default memory paths in tools

### DIFF
--- a/tools/debug_tokens.py
+++ b/tools/debug_tokens.py
@@ -2,8 +2,8 @@ import json
 import sys
 from transformers import GPT2TokenizerFast
 
-# Caminho para o arquivo de memória
-MEMORY_FILE = "memory/memory.json"
+# Caminho para o arquivo de memória padrão
+MEMORY_FILE = "memory/default/working_memory.json"
 
 def contar_tokens_mensagens(mensagens):
     tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")

--- a/tools/performance_test.py
+++ b/tools/performance_test.py
@@ -4,7 +4,8 @@ import sys
 import time
 from transformers import GPT2TokenizerFast
 
-MEMORY_FILE = "memory/memory.json"
+# Caminho para o arquivo de memória padrão
+MEMORY_FILE = "memory/default/working_memory.json"
 
 # Carrega tokenizer GPT-2
 try:


### PR DESCRIPTION
## Summary
- update paths in debug_tokens/performance_test to use hierarchical memory

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py "tools/teste_local.py"`


------
https://chatgpt.com/codex/tasks/task_e_684b660338d08327b219bdcd6c7fdeaa