### PR TITLE
Centralize LM_API_URL in config

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -18,10 +18,10 @@ from core.resumo import (
     resumo_branch,
     resumo_global,
 )
+from core.config import LM_API_URL
 
 # Caminho da personalidade base
 DEFAULT_PERSONALITY_FILE = "config/personality.txt"
-LM_API_URL = "http://localhost:1234/v1/chat/completions"
 
 # Carrega a personalidade do sistema
 with open(DEFAULT_PERSONALITY_FILE, "r", encoding="utf-8") as f:

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,2 @@
+LM_API_URL = "http://localhost:1234/v1/chat/completions"
+

--- a/core/resumo.py
+++ b/core/resumo.py
@@ -1,6 +1,6 @@
 import requests
 
-LM_API_URL = "http://localhost:1234/v1/chat/completions"
+from core.config import LM_API_URL
 
 def gerar_resumo_com_ia(trechos):
     prompt_resumo = "Resuma brevemente os principais tópicos da conversa a seguir:\n\n"


### PR DESCRIPTION
## Summary
- centralize `LM_API_URL` constant in a new `core/config.py`
- import the constant in `core/chat.py`
- import the constant in `core/resumo.py`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b6602999c8327bd4214f583f27f7d