### PR TITLE
Lazy load GPT2 tokenizer

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -5,8 +5,6 @@ import time
 import psutil
 import core.chat as chat
 from core.memoria import salvar_memoria, remover_ultimas_raw
-from transformers import GPT2TokenizerFast
-tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 
 PERSONALIDADES_DIR = "personalidades"
 USUARIOS_DIR = "usuarios"

--- a/tools/debug_tokens.py
+++ b/tools/debug_tokens.py
@@ -6,7 +6,11 @@ from transformers import GPT2TokenizerFast
 MEMORY_FILE = "memory/default/working_memory.json"
 
 def contar_tokens_mensagens(mensagens):
-    tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
+    try:
+        tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
+    except Exception as e:
+        print(f"Erro ao carregar tokenizer GPT-2: {e}")
+        return 0
     return sum(len(tokenizer.encode(m["content"])) for m in mensagens)
 
 def main(mem_file=MEMORY_FILE):

--- a/tools/performance_test.py
+++ b/tools/performance_test.py
@@ -7,15 +7,11 @@ from transformers import GPT2TokenizerFast
 # Caminho para o arquivo de memória padrão
 MEMORY_FILE = "memory/default/working_memory.json"
 
-# Carrega tokenizer GPT-2
-try:
-    tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
-except Exception as e:
-    print("Erro ao carregar tokenizer GPT-2:", e)
-    tokenizer = None
-
 def contar_tokens_mensagens(mensagens):
-    if not tokenizer:
+    try:
+        tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
+    except Exception as e:
+        print("Erro ao carregar tokenizer GPT-2:", e)
         return 0
     return sum(len(tokenizer.encode(m["content"])) for m in mensagens if m.get("content"))
 


### PR DESCRIPTION
## Summary
- remove global GPT2 tokenizer loading in `interface.py`
- load tokenizer lazily in debugging scripts

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`


------
https://chatgpt.com/codex/tasks/task_e_684b8a93ace083278bb510b80b0c9d28