### PR TITLE
Add memory reset tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ pip install -r requirements.txt
 - `personalidades/` – arquivos JSON com as personalidades disponíveis
 - `interface.py` – versão com interface web (Gradio)
 - `main.py` – versão para uso no terminal
-- `tools/` – scripts auxiliares para depuração e testes
+- `tools/` – scripts auxiliares para depuração e testes (inclui `reset_memory.py` para limpar a memória de um personagem)
 
 O arquivo de memória agora é salvo em `memory/<personagem>.json` e será criado automaticamente na primeira execução de cada personalidade.
 
@@ -39,6 +39,15 @@ python interface.py
 ```
 
 A aplicação abrirá um servidor local com chat em tempo real.
+
+### Resetar memória
+
+Para apagar todos os arquivos de memória de um personagem e começar do zero:
+
+```bash
+python tools/reset_memory.py nome_da_personalidade
+```
+
 
 ## Verificação Rápida
 

--- a/core/memoria.py
+++ b/core/memoria.py
@@ -2,6 +2,7 @@
 import json
 import os
 import warnings
+import shutil
 
 DEFAULT_MEMORY_DIR = "memory"
 DEFAULT_MEMORY_FILE = os.path.join(DEFAULT_MEMORY_DIR, "working_memory.json")
@@ -95,6 +96,17 @@ def init_hierarchical(base_dir):
             _save_json([], path)
     if not os.path.exists(os.path.join(base_dir, "meta.json")):
         _save_meta({"current_raw": 1, "count_in_raw": 0, "last_id": 0}, base_dir)
+
+
+def resetar_memoria_personagem(nome):
+    """Apaga e recria todos os arquivos de memória do *nome* informado."""
+    base = os.path.join(DEFAULT_MEMORY_DIR, nome)
+    if os.path.exists(base):
+        shutil.rmtree(base)
+    init_hierarchical(base)
+    caminho = os.path.join(base, "working_memory.json")
+    memoria = carregar_memoria(caminho)
+    salvar_memoria(memoria, caminho)
 
 
 def registrar_raw(role, content, base_dir):

--- a/tools/reset_memory.py
+++ b/tools/reset_memory.py
@@ -1,0 +1,11 @@
+import sys
+from core.memoria import resetar_memoria_personagem
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Uso: python tools/reset_memory.py <nome_personagem>")
+    else:
+        personagem = sys.argv[1]
+        resetar_memoria_personagem(personagem)
+        print(f"Memória de '{personagem}' reiniciada.")
+


### PR DESCRIPTION
## Summary
- add `resetar_memoria_personagem` to erase a character's memory
- expose new console utility `tools/reset_memory.py`
- document memory reset command in README

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py tools/reset_memory.py`

------
https://chatgpt.com/codex/tasks/task_e_684dbb4cea608327ab077dd21afb0c43