### PR TITLE
Add button to clear memory in Gradio UI

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -4,7 +4,11 @@ import json
 import time
 import psutil
 import core.chat as chat
-from core.memoria import salvar_memoria, remover_ultimas_raw
+from core.memoria import (
+    salvar_memoria,
+    remover_ultimas_raw,
+    resetar_memoria_personagem,
+)
 from transformers import GPT2TokenizerFast
 tokenizer = GPT2TokenizerFast.from_pretrained("gpt2")
 
@@ -99,11 +103,18 @@ def excluir_ultima_interacao(historico):
             salvar_memoria(chat.memoria, chat.memory_file)
     return historico, historico
 
+def resetar_memoria(nome):
+    """Remove todos os arquivos de memória do personagem e reinicia"""
+    resetar_memoria_personagem(PERSONALIDADES[nome]["id"])
+    inicializar_personalidade(nome)
+    return [], []
+
 chatbot = gr.Chatbot(label="Assistente IA", type="messages")
 entrada = gr.Textbox(placeholder="Digite sua pergunta...", label="Você:")
 estado = gr.State([])
 botao_carregar = gr.Button("🔄 Carregar histórico")
 botao_excluir = gr.Button("🗑️ Excluir última mensagem")
+botao_reset = gr.Button("🧹 Resetar memória")
 seletor = gr.Dropdown(list(PERSONALIDADES.keys()), label="Personalidade", value=PERSONALIDADE_PADRAO)
 metricas = gr.Textbox(label="Métricas de desempenho", interactive=False, lines=4)
 
@@ -118,6 +129,7 @@ with gr.Blocks(title="IA com Memória") as demo:
     with gr.Row():
         botao_carregar.render()
         botao_excluir.render()
+        botao_reset.render()
     
     estado.render()
     metricas.render()
@@ -125,6 +137,7 @@ with gr.Blocks(title="IA com Memória") as demo:
     entrada.submit(fn=responder, inputs=[entrada, estado], outputs=[chatbot, estado, metricas, entrada])
     botao_carregar.click(fn=carregar_historico, inputs=[], outputs=[chatbot, estado])
     botao_excluir.click(fn=excluir_ultima_interacao, inputs=estado, outputs=[chatbot, estado])
+    botao_reset.click(fn=resetar_memoria, inputs=seletor, outputs=[chatbot, estado])
     seletor.change(fn=escolher_personalidade, inputs=seletor, outputs=[chatbot, estado])
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include `resetar_memoria_personagem` in interface imports
- add `resetar_memoria` helper and button to reset conversation memory

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684dcd6c52f88327bfc022d924496ec2