### PR TITLE
Fix interaction counter after deletion

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -99,6 +99,8 @@ def excluir_ultima_interacao(historico):
         del historico[-2:]
         if chat.memoria.get("conversa"):
             chat.memoria["conversa"] = chat.memoria["conversa"][:-2]
+            if chat.memoria.get("contador_interacoes", 0) > 0:
+                chat.memoria["contador_interacoes"] -= 1
             remover_ultimas_raw(chat.memory_base, 2)
             salvar_memoria(chat.memoria, chat.memory_file)
     return historico, historico


### PR DESCRIPTION
## Summary
- decrement `contador_interacoes` when deleting the last interaction

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684dd43b62bc832782836219d49f83cc