### PR TITLE
Limit stored summaries to last 5

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -11,6 +11,7 @@ from core.memoria import (
     gerar_resumo_branch,
     gerar_resumo_global,
     buscar_trechos,
+    MAX_RESUMOS,
 )
 from core.contexto import montar_contexto
 from core.resumo import (
@@ -111,9 +112,11 @@ def conversar(pergunta):
     resumo_ep = gerar_resumo_episodio(memory_base, resumo_episodio)
     if resumo_ep:
         memoria["resumo_breve"].append(resumo_ep)
+        memoria["resumo_breve"] = memoria["resumo_breve"][-MAX_RESUMOS:]
     resumo_br = gerar_resumo_branch(memory_base, resumo_branch)
     if resumo_br:
         memoria["resumo_antigo"].append(resumo_br)
+        memoria["resumo_antigo"] = memoria["resumo_antigo"][-MAX_RESUMOS:]
     gerar_resumo_global(memory_base, resumo_global)
 
     salvar_memoria(memoria, memory_file)

--- a/core/memoria.py
+++ b/core/memoria.py
@@ -15,6 +15,7 @@ BRANCHES_PER_GLOBAL = 4
 VECTOR_DIR_NAME = "vectors"
 EPISODIC_VECTOR_FILE = "episodic_vectors.json"
 HISTORICAL_VECTOR_FILE = "historical_vectors.json"
+MAX_RESUMOS = 5
 
 
 def _text_embedding(text, size=32):
@@ -130,6 +131,10 @@ def carregar_memoria(arquivo=DEFAULT_MEMORY_FILE):
     memoria.setdefault("resumo_breve", [])
     memoria.setdefault("resumo_antigo", [])
     memoria.setdefault("contador_interacoes", 0)
+
+    # Limita o tamanho das listas de resumos para evitar crescimento indefinido
+    memoria["resumo_breve"] = memoria.get("resumo_breve", [])[-MAX_RESUMOS:]
+    memoria["resumo_antigo"] = memoria.get("resumo_antigo", [])[-MAX_RESUMOS:]
 
     return memoria
 


### PR DESCRIPTION
## Summary
- keep only the latest 5 episodic and historical summaries on load
- ensure the same truncation after generating new summaries
- run the quick compile check

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py "tools/teste local.py"` *(fails: No such file or directory)*
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684e112ffa2c832782bdb17c3f09814f