### PR TITLE
Remove resumo_antigo and reset snippet list

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -76,14 +76,15 @@ def conversar(pergunta):
     memoria["conversa"].append({"role": "assistant", "content": resposta})
 
     if memoria["contador_interacoes"] % 15 == 0:
-        trechos = [f"{'Usuário' if m['role']=='user' else 'IA'}: {m['content']}" for m in memoria["conversa"]]
+        # cria nova lista a cada busca para evitar acumulo desnecessário
+        trechos = [
+            f"{'Usuário' if m['role']=='user' else 'IA'}: {m['content']}"
+            for m in memoria["conversa"]
+        ]
         resumo = gerar_resumo_com_ia(trechos)
         memoria["resumo_breve"].append(resumo)
         if len(memoria["resumo_breve"]) > 10:
-            antigos = memoria["resumo_breve"][:3]
-            resumo_antigo = gerar_resumo_com_ia(antigos)
-            memoria["resumo_antigo"].append(resumo_antigo)
-            memoria["resumo_breve"] = memoria["resumo_breve"][3:]
+            memoria["resumo_breve"] = memoria["resumo_breve"][-10:]
 
     salvar_memoria(memoria, memory_file)
     return resposta

--- a/core/contexto.py
+++ b/core/contexto.py
@@ -6,5 +6,4 @@ Você é {memoria['personagem'].get('nome', 'uma IA')}, {memoria['personagem'].g
 Sua personalidade é: {memoria['personagem'].get('personalidade', 'neutra')}.
 Você está conversando com {memoria['usuario'].get('nome', 'o usuário')}, que gosta da cor {memoria['usuario'].get('preferencias', {}).get('cor', 'azul')}.
 Resumo breve: {', '.join(memoria.get('resumo_breve', []))}.
-Resumo antigo: {', '.join(memoria.get('resumo_antigo', []))}.
 """

--- a/core/memoria.py
+++ b/core/memoria.py
@@ -15,13 +15,11 @@ def carregar_memoria(arquivo=DEFAULT_MEMORY_FILE):
             "personagem": {},
             "conversa": [],
             "resumo_breve": [],
-            "resumo_antigo": [],
             "contador_interacoes": 0
         }
 
     # Garante que todas as chaves existam mesmo se o arquivo já existia
     memoria.setdefault("resumo_breve", [])
-    memoria.setdefault("resumo_antigo", [])
     memoria.setdefault("conversa", [])
     memoria.setdefault("contador_interacoes", 0)
 


### PR DESCRIPTION
## Summary
- drop `resumo_antigo` usage
- keep only the last 10 short summaries
- ensure snippet list is rebuilt every time

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py "tools/teste local.py"`

------
https://chatgpt.com/codex/tasks/task_e_684e1754f4108327872b809c71c518a6