### PR TITLE
Remove resumo_antigo from context and memory

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -113,10 +113,7 @@ def conversar(pergunta):
     if resumo_ep:
         memoria["resumo_breve"].append(resumo_ep)
         memoria["resumo_breve"] = memoria["resumo_breve"][-MAX_RESUMOS:]
-    resumo_br = gerar_resumo_branch(memory_base, resumo_branch)
-    if resumo_br:
-        memoria["resumo_antigo"].append(resumo_br)
-        memoria["resumo_antigo"] = memoria["resumo_antigo"][-MAX_RESUMOS:]
+    gerar_resumo_branch(memory_base, resumo_branch)
     gerar_resumo_global(memory_base, resumo_global)
 
     salvar_memoria(memoria, memory_file)

--- a/core/contexto.py
+++ b/core/contexto.py
@@ -6,5 +6,4 @@ Você é {memoria['personagem'].get('nome', 'uma IA')}, {memoria['personagem'].g
 Sua personalidade é: {memoria['personagem'].get('personalidade', 'neutra')}.
 Você está conversando com {memoria['usuario'].get('nome', 'o usuário')}, que gosta da cor {memoria['usuario'].get('preferencias', {}).get('cor', 'azul')}.
 Resumo breve: {', '.join(memoria.get('resumo_breve', []))}.
-Resumo antigo: {', '.join(memoria.get('resumo_antigo', []))}.
 """

--- a/core/memoria.py
+++ b/core/memoria.py
@@ -129,12 +129,10 @@ def carregar_memoria(arquivo=DEFAULT_MEMORY_FILE):
     memoria.setdefault("personagem", {})
     memoria.setdefault("conversa", [])
     memoria.setdefault("resumo_breve", [])
-    memoria.setdefault("resumo_antigo", [])
     memoria.setdefault("contador_interacoes", 0)
 
     # Limita o tamanho das listas de resumos para evitar crescimento indefinido
     memoria["resumo_breve"] = memoria.get("resumo_breve", [])[-MAX_RESUMOS:]
-    memoria["resumo_antigo"] = memoria.get("resumo_antigo", [])[-MAX_RESUMOS:]
 
     return memoria
 


### PR DESCRIPTION
## Summary
- drop `resumo_antigo` from context and memory handling
- keep branch summaries only in hierarchical storage

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py "tools/teste_local.py"`


------
https://chatgpt.com/codex/tasks/task_e_684e2f5e1ac88327a84bbb238b602e2b