### PR TITLE
Add confirmation for reset button

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -109,11 +109,15 @@ def excluir_ultima_interacao(historico):
             salvar_memoria(chat.memoria, chat.memory_file)
     return historico, historico, ""
 
-def resetar_memoria(nome):
-    """Remove todos os arquivos de memória do personagem e reinicia"""
+def resetar_memoria(nome, confirmar):
+    """Remove todos os arquivos de memória do personagem e reinicia."""
+    if not confirmar:
+        # Nenhuma alteração se o usuário não confirmou o reset
+        return gr.update(), gr.update(), gr.update(), False
+
     resetar_memoria_personagem(PERSONALIDADES[nome]["id"])
     inicializar_personalidade(nome)
-    return [], [], ""
+    return [], [], "", False
 
 chatbot = gr.Chatbot(label="Assistente IA", type="messages")
 entrada = gr.Textbox(placeholder="Digite sua pergunta...", label="Você:")
@@ -121,6 +125,7 @@ estado = gr.State([])
 botao_carregar = gr.Button("🔄 Carregar histórico")
 botao_excluir = gr.Button("🗑️ Excluir última mensagem")
 botao_reset = gr.Button("🧹 Resetar memória")
+confirmar_reset = gr.Checkbox(label="Confirmar reset", value=False)
 seletor = gr.Dropdown(list(PERSONALIDADES.keys()), label="Personalidade", value=PERSONALIDADE_PADRAO)
 metricas = gr.Textbox(label="Métricas de desempenho", interactive=False, lines=4)
 trechos_rag = gr.Textbox(label="Trechos recuperados (RAG)", interactive=False, lines=8)
@@ -137,6 +142,7 @@ with gr.Blocks(title="IA com Memória") as demo:
         botao_carregar.render()
         botao_excluir.render()
         botao_reset.render()
+        confirmar_reset.render()
     
     estado.render()
     metricas.render()
@@ -145,7 +151,11 @@ with gr.Blocks(title="IA com Memória") as demo:
     entrada.submit(fn=responder, inputs=[entrada, estado], outputs=[chatbot, estado, metricas, trechos_rag, entrada])
     botao_carregar.click(fn=carregar_historico, inputs=[], outputs=[chatbot, estado, trechos_rag])
     botao_excluir.click(fn=excluir_ultima_interacao, inputs=estado, outputs=[chatbot, estado, trechos_rag])
-    botao_reset.click(fn=resetar_memoria, inputs=seletor, outputs=[chatbot, estado, trechos_rag])
+    botao_reset.click(
+        fn=resetar_memoria,
+        inputs=[seletor, confirmar_reset],
+        outputs=[chatbot, estado, trechos_rag, confirmar_reset],
+    )
     seletor.change(fn=escolher_personalidade, inputs=seletor, outputs=[chatbot, estado, trechos_rag])
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add checkbox confirmation for memory reset
- use the checkbox in the UI before allowing reset

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684e42f35d408327bb907f000f25e17c