### PR TITLE
Improve memory retrieval with FAISS

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ IA_Personagem é uma plataforma de chat em que cada personagem é uma IA com per
 ## Requisitos
 
 - Python 3.10+
-- Dependências: `requests`, `gradio`, `psutil`, `transformers`
+- Dependências: `requests`, `gradio`, `psutil`, `transformers`, `faiss-cpu`
 
 Instale as dependências com:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 gradio
 psutil
 transformers
+faiss-cpu


### PR DESCRIPTION
## Summary
- add optional FAISS indexes for episodic and raw embeddings
- register embeddings for raw messages and search the most relevant snippet
- add `faiss-cpu` dependency
- document new dependency

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684e489f93248327b7c419efabc3e61d