### PR TITLE
Adjust NLTK resource handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ Instale as dependências com:
 pip install -r requirements.txt
 ```
 
+Também é preciso instalar os corpora `punkt` e `stopwords` do NLTK:
+
+```bash
+python -m nltk.downloader punkt stopwords
+```
+
 ## Estrutura
 
 - `core/` – módulos principais de chat, memória e contexto

--- a/topico/extrator.py
+++ b/topico/extrator.py
@@ -1,9 +1,19 @@
 import re
 import nltk
 from nltk.corpus import stopwords
+from nltk.data import find
 
-nltk.download("punkt", quiet=True)
-nltk.download("stopwords", quiet=True)
+
+def _ensure_resource(path: str, name: str) -> None:
+    """Baixa o recurso do NLTK se ele não estiver disponível."""
+    try:
+        find(path)
+    except LookupError:
+        nltk.download(name, quiet=True)
+
+
+_ensure_resource("tokenizers/punkt", "punkt")
+_ensure_resource("corpora/stopwords", "stopwords")
 
 stop_words = set(stopwords.words("portuguese"))
 


### PR DESCRIPTION
## Summary
- ensure NLTK corpora are present before calling `download`
- mention NLTK corpora installation in the README

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684f89140954832783cc1769179336e0