### PR TITLE
Improve error handling during chat requests

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -100,10 +100,13 @@ def conversar(pergunta):
                         token = data["choices"][0]["delta"].get("content", "")
                         resposta += token
                         yield token
-                    except:
+                    except Exception as e:
+                        print(f"Erro ao processar linha da resposta: {e}")
                         continue
-    except:
-        yield "[Erro: não foi possível gerar resposta]"
+    except Exception as e:
+        erro_msg = f"[Erro: não foi possível gerar resposta: {e}]"
+        print(erro_msg)
+        yield erro_msg
         return
 
     # Salva a resposta completa e registra em memória hierárquica


### PR DESCRIPTION
## Summary
- log the exception when parsing or making chat API calls
- include the error in the yielded error message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f89133cf0832787a4d4b6b54a5832