### PR TITLE
Adicionar truncador de mensagens

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -22,6 +22,7 @@ from core.resumo import (
     resumo_branch,
     resumo_global,
 )
+from core.truncador import limitar_mensagens_com_prompt
 
 # Caminho da personalidade base
 DEFAULT_PERSONALITY_FILE = "config/personality.txt"
@@ -73,17 +74,18 @@ def conversar(pergunta):
     if ultima_busca:
         contexto_memoria += "\nTrechos relevantes:\n" + "\n----\n".join(ultima_busca)
 
-    mensagens = [{"role": "system", "content": system_prompt + "\n\n" + contexto_memoria}]
     memoria["contador_interacoes"] += 1
-    memoria["conversa"] = memoria.get("conversa", [])[-10:]
-    mensagens.extend(memoria["conversa"])
-    mensagens.append({"role": "user", "content": pergunta_ctx})
+    mensagens = limitar_mensagens_com_prompt(
+        system_prompt + "\n\n" + contexto_memoria,
+        memoria.get("conversa", []),
+        pergunta_ctx,
+    )
 
     payload = {
         "model": "local-model",
         "messages": mensagens,
         "temperature": 0.7,
-        "max_tokens": 512,
+        "max_tokens": 3800,
         "stream": True
     }
 

--- a/core/truncador.py
+++ b/core/truncador.py
@@ -1,0 +1,44 @@
+"""Utilitários para truncar conversas conforme limite de tokens."""
+
+from typing import List, Dict
+
+
+def estimar_tokens(texto: str) -> int:
+    """Estima de forma simples o número de tokens de *texto*.
+
+    A heurística considera que cada token possui em média quatro caracteres.
+    Essa aproximação é suficiente para limitar o tamanho das conversas sem
+    depender de bibliotecas externas.
+    """
+    if not texto:
+        return 0
+    return max(1, len(texto) // 4)
+
+
+def _contar_tokens_mensagens(mensagens: List[Dict[str, str]]) -> int:
+    """Retorna o total estimado de tokens nas *mensagens*."""
+    total = 0
+    for msg in mensagens:
+        total += estimar_tokens(msg.get("content", ""))
+    return total
+
+
+def limitar_mensagens_com_prompt(prompt: str, conversa: List[Dict[str, str]], pergunta: str, limite: int = 3800) -> List[Dict[str, str]]:
+    """Monta lista de mensagens respeitando o *limite* de tokens.
+
+    - ``prompt`` será enviado como a primeira mensagem do sistema.
+    - ``conversa`` é a lista histórica de mensagens no formato ``{"role": ..., "content": ...}``.
+    - ``pergunta`` é a pergunta atual do usuário.
+
+    As mensagens mais antigas são descartadas até que o total estimado de tokens
+    fique abaixo do ``limite``.
+    """
+    mensagens = [{"role": "system", "content": prompt}]
+    historico = list(conversa)
+    historico.append({"role": "user", "content": pergunta})
+
+    while historico and _contar_tokens_mensagens(mensagens + historico) > limite:
+        historico.pop(0)
+
+    mensagens.extend(historico)
+    return mensagens


### PR DESCRIPTION
## Summary
- adicionar utilitário de truncamento e estimativa de tokens
- usar `limitar_mensagens_com_prompt` em `core.chat`
- aumentar `max_tokens` para 3800

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684f8911a1d48327af96d7ae79703576