### PR TITLE
Fix topic usage for RAG retrieval

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -68,6 +68,8 @@ def conversar(pergunta):
     global memoria, ultima_busca
 
     pergunta_ctx = contextualizar_pergunta(pergunta, memoria)
+    # Usamos a pergunta enriquecida com tópicos apenas na busca por trechos
+    # semelhantes. A pergunta original é enviada ao modelo de linguagem.
     ultima_busca = buscar_trechos(pergunta_ctx, memory_base)
 
     contexto_memoria = montar_contexto(memoria)
@@ -78,7 +80,7 @@ def conversar(pergunta):
     mensagens = limitar_mensagens_com_prompt(
         system_prompt + "\n\n" + contexto_memoria,
         memoria.get("conversa", []),
-        pergunta_ctx,
+        pergunta,
     )
 
     payload = {


### PR DESCRIPTION
## Summary
- limit use of contextualized question to RAG search

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_684f917af7c883279b9599b1198dc4aa