### PR TITLE
Add token usage metrics

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -48,10 +48,15 @@ memoria = carregar_memoria(memory_file)
 
 # Últimos trechos recuperados pelo RAG
 ultima_busca = []
+ultima_metricas = {}
 
 def get_ultima_busca():
     """Retorna os trechos recuperados mais recentemente."""
     return ultima_busca
+
+def get_ultima_metricas():
+    """Retorna as métricas de tokens da última chamada."""
+    return ultima_metricas
 
 def set_system_prompt(novo_prompt):
     global system_prompt
@@ -87,11 +92,14 @@ def conversar(pergunta):
         contexto_memoria += "\nTrechos relevantes:\n" + "\n----\n".join(ultima_busca)
 
     memoria["contador_interacoes"] += 1
-    mensagens = limitar_mensagens_com_prompt(
+    mensagens, ultima_metricas_local = limitar_mensagens_com_prompt(
         system_prompt + "\n\n" + contexto_memoria,
         memoria.get("conversa", []),
         pergunta,
+        return_metrics=True,
     )
+    global ultima_metricas
+    ultima_metricas = ultima_metricas_local or {}
 
     payload = {
         "model": "local-model",

--- a/core/truncador.py
+++ b/core/truncador.py
@@ -1,6 +1,6 @@
 """Utilitários para truncar conversas conforme limite de tokens."""
 
-from typing import List, Dict
+from typing import List, Dict, Tuple, Optional
 
 
 def estimar_tokens(texto: str) -> int:
@@ -23,7 +23,13 @@ def _contar_tokens_mensagens(mensagens: List[Dict[str, str]]) -> int:
     return total
 
 
-def limitar_mensagens_com_prompt(prompt: str, conversa: List[Dict[str, str]], pergunta: str, limite: int = 3000) -> List[Dict[str, str]]:
+def limitar_mensagens_com_prompt(
+    prompt: str,
+    conversa: List[Dict[str, str]],
+    pergunta: str,
+    limite: int = 3000,
+    return_metrics: bool = False,
+) -> Tuple[List[Dict[str, str]], Optional[Dict[str, int]]]:
     """Monta lista de mensagens respeitando o *limite* de tokens.
 
     - ``prompt`` será enviado como a primeira mensagem do sistema.
@@ -37,8 +43,23 @@ def limitar_mensagens_com_prompt(prompt: str, conversa: List[Dict[str, str]], pe
     historico = list(conversa)
     historico.append({"role": "user", "content": pergunta})
 
+    tokens_prompt = estimar_tokens(prompt)
+    tokens_original = tokens_prompt + _contar_tokens_mensagens(historico)
+
     while historico and _contar_tokens_mensagens(mensagens + historico) > limite:
         historico.pop(0)
 
     mensagens.extend(historico)
-    return mensagens
+
+    metrics = None
+    if return_metrics:
+        tokens_final = _contar_tokens_mensagens(mensagens)
+        metrics = {
+            "limite": limite,
+            "tokens_prompt": tokens_prompt,
+            "tokens_original": tokens_original,
+            "tokens_final": tokens_final,
+            "prompt_truncado": tokens_prompt > limite,
+            "conversa_truncada": tokens_final < tokens_original,
+        }
+    return mensagens, metrics

--- a/interface.py
+++ b/interface.py
@@ -84,6 +84,16 @@ def responder(pergunta, historico):
         f"💾 RAM: {ram_usage_mb:.1f} MB"
     )
 
+    ctx = chat.get_ultima_metricas()
+    if ctx:
+        metricas += (
+            f"\n📄 Tokens contexto: {ctx['tokens_final']}/{ctx['limite']}"
+        )
+        if ctx.get('prompt_truncado'):
+            metricas += "\n⚠️ Prompt do sistema truncado"
+        elif ctx.get('conversa_truncada'):
+            metricas += "\n⚠️ Histórico truncado"
+
     trechos = chat.get_ultima_busca()
     trechos_str = "\n\n----\n\n".join(trechos)
 


### PR DESCRIPTION
## Summary
- return token metrics from message truncation
- expose token metric access in chat
- display token counts and truncation alerts in UI

## Testing
- `python -m py_compile core/truncador.py core/chat.py interface.py`

------
https://chatgpt.com/codex/tasks/task_e_684fa07d94288327a15b82299447dcea