### PR TITLE
Implement modular prompt assembly

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -13,7 +13,7 @@ from core.memoria import (
     buscar_trechos,
     MAX_RESUMOS,
 )
-from core.contexto import montar_contexto
+from core.contexto import montar_prompt
 from topico.extrator import atualizar_topicos_ativos
 from topico.contextualizador import contextualizar_pergunta
 from core.resumo import (
@@ -22,7 +22,7 @@ from core.resumo import (
     resumo_branch,
     resumo_global,
 )
-from core.truncador import limitar_mensagens_com_prompt
+from core.truncador import limitar_mensagens
 
 # Caminho da personalidade base
 DEFAULT_PERSONALITY_FILE = "config/personality.txt"
@@ -87,17 +87,9 @@ def conversar(pergunta):
     # semelhantes. A pergunta original é enviada ao modelo de linguagem.
     ultima_busca = buscar_trechos(pergunta_ctx, memory_base)
 
-    contexto_memoria = montar_contexto(memoria)
-    if ultima_busca:
-        contexto_memoria += "\nTrechos relevantes:\n" + "\n----\n".join(ultima_busca)
-
     memoria["contador_interacoes"] += 1
-    mensagens, ultima_metricas_local = limitar_mensagens_com_prompt(
-        system_prompt + "\n\n" + contexto_memoria,
-        memoria.get("conversa", []),
-        pergunta,
-        return_metrics=True,
-    )
+    mensagens = montar_prompt(system_prompt, pergunta, memoria, rag_trechos=ultima_busca)
+    mensagens, ultima_metricas_local = limitar_mensagens(mensagens, return_metrics=True)
     global ultima_metricas
     ultima_metricas = ultima_metricas_local or {}
 

--- a/core/contexto.py
+++ b/core/contexto.py
@@ -1,9 +1,35 @@
-# contexto.py
+"""Funções utilitárias para organizar o contexto enviado ao modelo."""
 
-def montar_contexto(memoria):
-    return f"""
-Você é {memoria['personagem'].get('nome', 'Sem nome')}, {memoria['personagem'].get('raça', 'uma IA')}, do genero {memoria['personagem'].get('genero', 'sem genero')}, {memoria['personagem'].get('origem', 'sem origem definida')}.
-Sua personalidade é: {memoria['personagem'].get('personalidade', 'neutra')}.
-Você está conversando com {memoria['usuario'].get('nome', 'o usuário')}.
-Resumo breve: {', '.join(memoria.get('resumo_breve', []))}.
-"""
+from typing import List, Dict
+
+
+def _montar_resumos(memoria: dict) -> List[Dict[str, str]]:
+    """Retorna até três mensagens de resumo em ordem mais recente."""
+    resumos = memoria.get("resumo_breve", [])[-3:]
+    mensagens = []
+    for resumo in resumos:
+        mensagens.append({"role": "system", "content": f"Resumo breve: {resumo}"})
+    return mensagens
+
+
+def _montar_interacoes(memoria: dict, n: int = 4) -> List[Dict[str, str]]:
+    """Retorna as últimas *n* mensagens do chat mantendo seus roles."""
+    interacoes = memoria.get("conversa", [])[-n:]
+    return list(interacoes)
+
+
+def montar_prompt(system_prompt: str, pergunta: str, memoria: dict, rag_trechos: List[str] | None = None) -> List[Dict[str, str]]:
+    """Monta a lista final de mensagens para o modelo."""
+
+    mensagens: List[Dict[str, str]] = [{"role": "system", "content": system_prompt}]
+
+    mensagens.extend(_montar_resumos(memoria))
+    mensagens.extend(_montar_interacoes(memoria))
+
+    if rag_trechos:
+        texto = "\n----\n".join(rag_trechos)
+        mensagens.append({"role": "system", "content": "Trechos relevantes:\n" + texto})
+
+    mensagens.append({"role": "user", "content": pergunta})
+    return mensagens
+

--- a/core/truncador.py
+++ b/core/truncador.py
@@ -30,15 +30,8 @@ def limitar_mensagens_com_prompt(
     limite: int = 3000,
     return_metrics: bool = False,
 ) -> Tuple[List[Dict[str, str]], Optional[Dict[str, int]]]:
-    """Monta lista de mensagens respeitando o *limite* de tokens.
+    """Mantida para compatibilidade: monta mensagens com um único ``prompt``."""
 
-    - ``prompt`` será enviado como a primeira mensagem do sistema.
-    - ``conversa`` é a lista histórica de mensagens no formato ``{"role": ..., "content": ...}``.
-    - ``pergunta`` é a pergunta atual do usuário.
-
-    As mensagens mais antigas são descartadas até que o total estimado de tokens
-    fique abaixo do ``limite``.
-    """
     mensagens = [{"role": "system", "content": prompt}]
     historico = list(conversa)
     historico.append({"role": "user", "content": pergunta})
@@ -61,5 +54,40 @@ def limitar_mensagens_com_prompt(
             "tokens_final": tokens_final,
             "prompt_truncado": tokens_prompt > limite,
             "conversa_truncada": tokens_final < tokens_original,
+        }
+    return mensagens, metrics
+
+
+def limitar_mensagens(
+    mensagens: List[Dict[str, str]],
+    limite: int = 3000,
+    return_metrics: bool = False,
+) -> Tuple[List[Dict[str, str]], Optional[Dict[str, int]]]:
+    """Limita o contexto removendo apenas mensagens da conversa."""
+
+    tokens_original = _contar_tokens_mensagens(mensagens)
+
+    # mensagens da conversa (exceto a última pergunta) possuem role user/assistant
+    conversacao_idx = [
+        i
+        for i, m in enumerate(mensagens[:-1])
+        if m.get("role") in {"user", "assistant"}
+    ]
+
+    while (
+        conversacao_idx
+        and _contar_tokens_mensagens(mensagens) > limite
+    ):
+        idx = conversacao_idx.pop(0)
+        mensagens.pop(idx)
+        conversacao_idx = [i - 1 if i > idx else i for i in conversacao_idx]
+
+    metrics = None
+    if return_metrics:
+        tokens_final = _contar_tokens_mensagens(mensagens)
+        metrics = {
+            "limite": limite,
+            "tokens_original": tokens_original,
+            "tokens_final": tokens_final,
         }
     return mensagens, metrics


### PR DESCRIPTION
## Summary
- rework context to build separate system prompts for summaries, recent interactions and RAG snippets
- add new limiter for generic message lists
- adjust chat flow to use new modular prompt builder
- keep conversation history as user/assistant messages rather than a system block
- fix limiter to remove only conversation messages

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py core/truncador.py tools/debug_tokens.py tools/performance_test.py "tools/teste_local.py"`


------
https://chatgpt.com/codex/tasks/task_e_6850d70532e08327afd49945e64a0a88