### PR TITLE
Improve streaming parsing

### DIFF
--- a/core/chat.py
+++ b/core/chat.py
@@ -111,8 +111,10 @@ def conversar(pergunta):
             for linha in response.iter_lines():
                 if linha:
                     try:
-                        linha = linha.decode("utf-8").replace("data: ", "")
-                        if linha.strip() == "[DONE]":
+                        linha = linha.decode("utf-8").strip()
+                        if linha.startswith("data:"):
+                            linha = linha[len("data:"):].strip()
+                        if linha == "[DONE]":
                             break
                         data = json.loads(linha)
                         token = data["choices"][0]["delta"].get("content", "")


### PR DESCRIPTION
## Summary
- handle `response.iter_lines()` more robustly

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `printf 'oi\nsair\n' | python main.py aria` *(fails: Resource stopwords not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850ee72debc8327b2db67215a268a06