### PR TITLE
Optimize modules and improve README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,49 @@
 # IA_Personagem
 
-IA_Personagem é uma plataforma de chat em que cada personagem é uma IA com personalidade própria. O sistema mantém memória hierárquica da conversa e pode ser utilizado via terminal ou interface web (Gradio).
+IA_Personagem é uma aplicação de chat com múltiplas personalidades e memória hierárquica. Cada personagem possui um prompt próprio e guarda o histórico das conversas para gerar resumos automáticos. O sistema funciona tanto via terminal quanto por uma interface web em Gradio.
 
-## Requisitos
+## Principais funcionalidades
 
-- Python 3.10+
-- Dependências: `requests`, `gradio`, `psutil`, `transformers`, `faiss-cpu`, `nltk`
+- **Personalidades customizadas** em `personalidades/*.json`.
+- **Memória hierárquica** com arquivos brutos, resumos de episódios e históricos.
+- **Armazenamento de embeddings** para busca de trechos relevantes (RAG).
+- **Interface web** opcional com Gradio (`interface.py`).
+- **Uso pelo terminal** através de `main.py`.
+- **Scripts utilitários** em `tools/` para depuração e reset de memória.
 
-Instale as dependências com:
+## Como o código funciona
+
+1. **Chat** (`core/chat.py`)
+   - Monta o prompt combinando o prompt do sistema, resumos e histórico.
+   - Envia as mensagens para um modelo em `http://localhost:1234/v1/chat/completions`.
+   - Registra as respostas na memória e atualiza os resumos.
+2. **Memória** (`core/memoria.py`)
+   - Guarda mensagens brutas em arquivos `memory/<persona>/raw/`.
+   - Cria resumos periódicos (episódios, branches e global).
+   - Converte resumos e mensagens em embeddings determinísticos (opcionalmente com FAISS).
+3. **Contexto e tópicos** (`core/contexto.py`, `topico/`)
+   - Extrai tópicos recentes para enriquecer perguntas.
+   - Constrói a lista de mensagens que será enviada ao modelo.
+4. **Interfaces**
+   - `main.py` executa o chat no terminal.
+   - `interface.py` oferece uma interface web com histórico e ações de gerenciamento.
+
+## Instalação
+
+Requer Python 3.10+. Instale as dependências:
 
 ```bash
 pip install -r requirements.txt
-```
-
-Também é preciso instalar os corpora `punkt` e `stopwords` do NLTK:
-
-```bash
 python -m nltk.downloader punkt stopwords
 ```
 
-## Estrutura
-
-- `core/` – módulos principais de chat, memória e contexto
-- `personalidades/` – arquivos JSON com as personalidades disponíveis
-- `interface.py` – versão com interface web (Gradio)
-- `main.py` – versão para uso no terminal
-- `tools/` – scripts auxiliares para depuração e testes (inclui `reset_memory.py` para limpar a memória de um personagem)
-
-O arquivo de memória agora é salvo em `memory/<personagem>.json` e será criado automaticamente na primeira execução de cada personalidade.
-
-## Executando
+## Execução rápida
 
 ### Terminal
 
 ```bash
-python main.py nome_da_personalidade
+python main.py aria  # escolha a personalidade desejada
 ```
-Substitua `nome_da_personalidade` pelo arquivo desejado em `personalidades/` (ex.: `aria` ou `beto`).
 
 ### Interface Web
 
@@ -44,33 +51,17 @@ Substitua `nome_da_personalidade` pelo arquivo desejado em `personalidades/` (ex
 python interface.py
 ```
 
-A aplicação abrirá um servidor local com chat em tempo real.
-
 ### Resetar memória
 
-Para apagar todos os arquivos de memória de um personagem e começar do zero:
-
 ```bash
-python tools/reset_memory.py nome_da_personalidade
+python tools/reset_memory.py aria
 ```
 
-### Vetores de resumo
+## Verificação rápida
 
-Os resumos gerados são convertidos em embeddings determinísticos e
-armazenados em `memory/<personagem>/vectors/`. Existem dois arquivos:
-`episodic_vectors.json` e `historical_vectors.json`, cada um contendo o
-`id` do resumo e seu vetor. Com o `id` é possível consultar o intervalo
-de mensagens correspondentes nos arquivos `raw`, permitindo recuperar a
-memória original.
-
-
-## Verificação Rápida
-
-Para verificar a integridade do código Python:
+Para garantir que os arquivos Python estão corretos:
 
 ```bash
-python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py "tools/teste local.py"
+python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py
 ```
-
-Os scripts em `tools/` dependem da biblioteca `transformers` para calcular tokens. Caso ela não esteja instalada, esses scripts exibirão um erro.
 

--- a/core/chat.py
+++ b/core/chat.py
@@ -80,7 +80,6 @@ def carregar_personalidade(arquivo_json):
 def conversar(pergunta):
     global memoria, ultima_busca
 
-    DEBUG_CHAT = 1
 
     pergunta_ctx = contextualizar_pergunta(pergunta, memoria)
     # Usamos a pergunta enriquecida com tópicos apenas na busca por trechos

--- a/core/memoria.py
+++ b/core/memoria.py
@@ -5,6 +5,9 @@ import warnings
 import shutil
 import hashlib
 from typing import List, Tuple
+import re
+
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?]) +")
 
 try:
     import faiss  # type: ignore
@@ -39,20 +42,22 @@ def _text_embedding(text, size=32):
 
 def dividir_em_chunks(texto: str, max_tokens: int = 64) -> List[str]:
     """Divide *texto* em chunks de até *max_tokens* palavras."""
-    import re
-
-    sentencas = re.split(r"(?<=[.!?]) +", texto)
+    sentencas = SENTENCE_SPLIT_RE.split(texto)
     chunks = []
-    atual = ""
+    atual: List[str] = []
+    count = 0
     for s in sentencas:
-        if len(atual.split()) + len(s.split()) <= max_tokens:
-            atual = f"{atual} {s}".strip()
+        palavras = s.split()
+        if count + len(palavras) <= max_tokens:
+            atual.extend(palavras)
+            count += len(palavras)
         else:
             if atual:
-                chunks.append(atual)
-            atual = s
+                chunks.append(" ".join(atual))
+            atual = palavras
+            count = len(palavras)
     if atual:
-        chunks.append(atual.strip())
+        chunks.append(" ".join(atual))
     return chunks
 
 

--- a/topico/extrator.py
+++ b/topico/extrator.py
@@ -15,6 +15,7 @@ def _ensure_resource(path: str, name: str) -> None:
 _ensure_resource("tokenizers/punkt", "punkt")
 _ensure_resource("corpora/stopwords", "stopwords")
 
+_CLEAN_RE = re.compile(r"[^\w\s]")
 stop_words = set(stopwords.words("portuguese"))
 
 # === Configurações ===
@@ -25,7 +26,7 @@ MIN_PESO = 1    # elimina tópicos com peso abaixo disso
 # === Extração por frequência e posição ===
 def extrair_topicos(texto: str, max_topicos: int = 3):
     """Retorna lista com os *max_topicos* mais relevantes."""
-    texto_limpo = re.sub(r"[^\w\s]", "", texto.lower())
+    texto_limpo = _CLEAN_RE.sub("", texto.lower())
     palavras = nltk.word_tokenize(texto_limpo)
     palavras_relevantes = [p for p in palavras if p not in stop_words and len(p) > 3]
 


### PR DESCRIPTION
## Summary
- remove stray debug flag from chat
- reduce regex compilation overhead
- speed up chunk splitting
- rewrite README with main features and usage

## Testing
- `python -m py_compile interface.py main.py core/chat.py core/memoria.py core/contexto.py core/resumo.py tools/debug_tokens.py tools/performance_test.py tools/teste_local.py`

------
https://chatgpt.com/codex/tasks/task_e_68510476012883279b7e77575de960b1